### PR TITLE
Add support for click version 8.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for `click>=8.3`
+
 ## 1.2.0
 
 - `click-type-test` now requires `click<8.3`, until support for version 8.3 can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = ["click>=8.1.0,<8.3"]
+dependencies = ["click>=8.1.0"]
 
 [project.urls]
 source = "https://github.com/sirosen/click-type-test"

--- a/test/unit/test_basic_usages.py
+++ b/test/unit/test_basic_usages.py
@@ -27,6 +27,11 @@ def test_deduce_type_from_string_opt():
     assert deduce_type_from_parameter(opt) == (str | None)
 
 
+def test_deduce_type_from_string_opt_with_explicit_default_of_none():
+    opt = click.Option(["--foo"], default=None)
+    assert deduce_type_from_parameter(opt) == (str | None)
+
+
 def test_deduce_type_from_required_string_opt():
     opt = click.Option(["--foo"], required=True)
     assert deduce_type_from_parameter(opt) == str


### PR DESCRIPTION
The `default` attribute of options and optional-arguments is now `UNSET`,
an internal sentinel defined for use within `click`.

Rather than checking if `default is not None` to see if there is a
"set default" on an argument, we now check
`default not in [UNSET, None]`.

A new test case covers an explicit `default=None`, which guarantees that
in future versions, we won't start assuming that only `default=UNSET`
indicates nullability.
