### PR TITLE
Switch to `to_info_dict()` for param inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Switch to `to_info_dict()` for parameter inspection, improving compatibility
+  with various `click` versions
+
 ## 1.3.0
 
 - Add support for `click>=8.3`


### PR DESCRIPTION
This is the documented interface for getting various properties. As
such, it handles resolution of `default`s from `UNSET` to `None`, and
provides a better forward-compatibility guarantee.
